### PR TITLE
0.1.6

### DIFF
--- a/CraftableCartography/CraftableCartographyModSystem.cs
+++ b/CraftableCartography/CraftableCartographyModSystem.cs
@@ -113,6 +113,7 @@ namespace CraftableCartography
             capi = api;
 
             api.ChatCommands.Create("recentremap")
+                .WithAlias("recentermap")
                 .WithDescription("Recentres your map on the given coordinates")
                 .RequiresPlayer()
                 .WithArgs(new ICommandArgumentParser[] { api.ChatCommands.Parsers.OptionalInt("x"), api.ChatCommands.Parsers.OptionalInt("y"), api.ChatCommands.Parsers.OptionalInt("z") })

--- a/CraftableCartography/Patches/MapGuiPatches.cs
+++ b/CraftableCartography/Patches/MapGuiPatches.cs
@@ -5,6 +5,7 @@ using Vintagestory.API.Datastructures;
 using Vintagestory.API.MathTools;
 using Vintagestory.GameContent;
 using static CraftableCartography.Lib.CCConstants;
+using static CraftableCartography.Lib.ItemChecks;
 
 namespace CraftableCartography.Patches
 {
@@ -67,8 +68,13 @@ namespace CraftableCartography.Patches
                             {
                                 if (capi.World.Player.Entity != null)
                                 {
-                                    Vec3d playerPos = capi.World.Player.Entity.Pos.XYZ;
-                                    traverse.Field("prevPlayerPos").GetValue<Vec3d>().Set(playerPos.X, playerPos.Y, playerPos.Z);
+                                    MapChecker mapChecker = capi.ModLoader.GetModSystem<MapChecker>();
+
+                                    if (!HasJPS(capi.World.Player))
+                                    {
+                                        Vec3d playerPos = capi.World.Player.Entity.Pos.XYZ;
+                                        traverse.Field("prevPlayerPos").GetValue<Vec3d>().Set(playerPos.X, playerPos.Y, playerPos.Z);
+                                    }
                                 }
                             }
                         }

--- a/CraftableCartography/Patches/MapGuiPatches.cs
+++ b/CraftableCartography/Patches/MapGuiPatches.cs
@@ -82,5 +82,16 @@ namespace CraftableCartography.Patches
                 }
             }
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(GuiElementMap), nameof(GuiElementMap.OnKeyDown))]
+        public static bool SpaceBarPressedCheck(GuiElementMap __instance, ICoreClientAPI api, KeyEvent args)
+        {
+            if (args.KeyCode == 51)
+            {
+                if (!HasJPS(api.World.Player)) return false;
+            }
+            return true;
+        }
     }
 }

--- a/CraftableCartography/Patches/ProPickPatches.cs
+++ b/CraftableCartography/Patches/ProPickPatches.cs
@@ -1,0 +1,38 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.API.Common;
+using Vintagestory.API.Config;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+using Vintagestory.GameContent;
+using static CraftableCartography.Lib.ItemChecks;
+
+namespace CraftableCartography.Patches
+{
+    [HarmonyPatch]
+    internal class ProPickPatches
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ItemProspectingPick), "PrintProbeResults")]
+        public static bool PrintProbeResults(ItemProspectingPick __instance, IWorldAccessor world, IServerPlayer splr, ItemSlot itemslot, BlockPos pos)
+        {
+            if (HasJPS(splr)) return true;
+
+            Traverse traverse = Traverse.Create(__instance);
+
+            PropickReading results = traverse.Method("GenProbeResults", new Type[] { typeof(IWorldAccessor), typeof(BlockPos) }).GetValue<PropickReading>(world, pos);
+            string textResults = results.ToHumanReadable(splr.LanguageCode, traverse.Field("ppws").GetValue<ProPickWorkSpace>().pageCodes);
+            splr.SendMessage(GlobalConstants.InfoLogChatGroup, textResults, EnumChatType.Notification, null);
+
+            splr.SendMessage(GlobalConstants.InfoLogChatGroup, "Enter coordinates with /setreading to save to map", EnumChatType.Notification);
+
+            world.Api.ModLoader.GetModSystem<CraftableCartographyModSystem>().StoreLastReading(splr, results);
+
+            return false;
+        }
+    }
+}

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,3 +1,3 @@
 - Fix: map now continues to track player movement if you have a JPS
 - You can no longer recentre the map on your position by pressing space unless you have a JPS
-- 
+- Prospecting pick mechanics updated: you must now manually enter the coordinates of a reading unless you have a JPS

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -2,3 +2,4 @@
 - You can no longer recentre the map on your position by pressing space unless you have a JPS
 - Prospecting pick mechanics updated: you must now manually enter the coordinates of a reading unless you have a JPS
 - Added .recentermap as an alias of .recentremap
+- Fix: JPS recipe no longer consumes the knife and wrench

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,1 +1,3 @@
-- Fix: map now continues to track player if you have a JPS
+- Fix: map now continues to track player movement if you have a JPS
+- You can no longer recentre the map on your position by pressing space unless you have a JPS
+- 

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,3 +1,4 @@
 - Fix: map now continues to track player movement if you have a JPS
 - You can no longer recentre the map on your position by pressing space unless you have a JPS
 - Prospecting pick mechanics updated: you must now manually enter the coordinates of a reading unless you have a JPS
+- Added .recentermap as an alias of .recentremap

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,3 +1,1 @@
-- Fix: JPS & channel requirement to see other players on map should work now
-- Increased compass damping slightly
-- Added degrees symbol to compass display
+- Fix: map now continues to track player if you have a JPS

--- a/resources/assets/craftablecartography/recipes/grid/jps.json
+++ b/resources/assets/craftablecartography/recipes/grid/jps.json
@@ -26,11 +26,13 @@
     },
     "K": {
       "type": "item",
-      "code": "game:knife-*"
+      "code": "game:knife-*",
+      "isTool": true
     },
     "W": {
       "type": "item",
-      "code": "game:wrench-*"
+      "code": "game:wrench-*",
+      "isTool": true
     },
     "G": {
       "type": "item",

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "A more immersive map & navigation experience",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "dependencies": {
         "game": "*"
     }


### PR DESCRIPTION
- Fix: map now continues to track player movement if you have a JPS
- You can no longer recentre the map on your position by pressing space unless you have a JPS
- Prospecting pick mechanics updated: you must now manually enter the coordinates of a reading unless you have a JPS
- Added .recentermap as an alias of .recentremap
- Fix: JPS recipe no longer consumes the knife and wrench