### PR TITLE
Compass recipe support for both VS 1.20 and 1.21

### DIFF
--- a/resources/assets/craftablecartography/recipes/grid/compass.json
+++ b/resources/assets/craftablecartography/recipes/grid/compass.json
@@ -13,7 +13,7 @@
     },
     "B": {
       "type": "block",
-      "code": "game:bowl-*-fired"
+      "code": "game:bowl-*fired"
     },
     "P": {
       "type": "item",

--- a/resources/assets/craftablecartography/recipes/grid/compassprimitive.json
+++ b/resources/assets/craftablecartography/recipes/grid/compassprimitive.json
@@ -9,7 +9,7 @@
     },
     "B": {
       "type": "block",
-      "code": "game:bowl-*-fired"
+      "code": "game:bowl-*fired"
     }
   },
   "attributes": {


### PR DESCRIPTION
in 1.20 the id is `game:bowl-fired`
in 1.21 the id is `game:bowl-<type>-fired`

by using `game:bowl-*fired`, both are valid.