### PR TITLE
Compass needle

### DIFF
--- a/CraftableCartography/Config/CraftableCartographyModConfig.cs
+++ b/CraftableCartography/Config/CraftableCartographyModConfig.cs
@@ -2,6 +2,7 @@
 {
     public class CraftableCartographyModConfig
     {
-        public bool AllowMapOpeningWithoutTool = false;
+        public bool AllowMapOpeningWithoutTool = true;
+        public bool CompassTextBox = false;
     }
 }

--- a/CraftableCartography/Items/Compass/Compass.cs
+++ b/CraftableCartography/Items/Compass/Compass.cs
@@ -14,12 +14,13 @@ namespace CraftableCartography.Items.Compass
     public class Compass : Item
     {
         HudElementNavReading gui;
+        HudCompassNeedleRenderer needleRenderer;
 
         float heading;
         float headingDelta;
 
-        float damping = 0.92f;
-        float accelerationMult = 4f;
+        float damping = 0.96f;
+        float accelerationMult = 6f;
 
         long lastUpdate;
 
@@ -30,6 +31,9 @@ namespace CraftableCartography.Items.Compass
                 gui ??= new((ICoreClientAPI)byEntity.Api);
                 gui.TryOpen();
                 gui.SetText(GetText());
+
+                needleRenderer = new((ICoreClientAPI)byEntity.Api);
+                needleRenderer.heading = heading;
             }
             
             handling = EnumHandHandling.PreventDefault;
@@ -92,6 +96,8 @@ namespace CraftableCartography.Items.Compass
                 DoMoveStep(byEntity);
 
                 gui.SetText(GetText());
+
+                needleRenderer.heading = heading;
             }
 
             return true;
@@ -100,7 +106,12 @@ namespace CraftableCartography.Items.Compass
         public override void OnHeldInteractStop(float secondsUsed, ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel)
         {
             if (byEntity.Api.Side == EnumAppSide.Client)
+            {
                 gui.TryClose();
+
+                needleRenderer.Dispose();
+                needleRenderer = null;
+            }
         }
 
         public override void OnHeldIdle(ItemSlot slot, EntityAgent byEntity)

--- a/CraftableCartography/Items/Compass/Compass.cs
+++ b/CraftableCartography/Items/Compass/Compass.cs
@@ -20,7 +20,7 @@ namespace CraftableCartography.Items.Compass
         float headingDelta;
 
         float damping = 0.96f;
-        float accelerationMult = 6f;
+        float accelerationMult = 5.6f;
 
         long lastUpdate;
 
@@ -131,5 +131,21 @@ namespace CraftableCartography.Items.Compass
             
             return true;
         }
+        /*
+        public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
+        {
+            base.OnBeforeRender(capi, itemstack, target, ref renderinfo);
+
+            Shape shape = Vintagestory.API.Common.Shape.TryGet(api, Code);
+
+            shape.GetElementByName("needle").RotationY = heading;
+
+            MeshData compassMesh;
+
+            capi.Tesselator.TesselateShape(this, shape, out compassMesh);
+
+            renderinfo.ModelRef = capi.Render.UploadMultiTextureMesh(compassMesh);
+        }
+        */
     }
 }

--- a/CraftableCartography/Items/Compass/Compass.cs
+++ b/CraftableCartography/Items/Compass/Compass.cs
@@ -7,6 +7,7 @@ using CraftableCartography.Items.Shared;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
+using Vintagestory.API.Config;
 using Vintagestory.API.MathTools;
 
 namespace CraftableCartography.Items.Compass
@@ -32,19 +33,26 @@ namespace CraftableCartography.Items.Compass
                 gui.TryOpen();
                 gui.SetText(GetText());
 
-                CompositeTexture compositeTexture;
-                if (Textures.TryGetValue("tinbronze", out compositeTexture))
-                {
-                    needleRenderer = new((ICoreClientAPI)byEntity.Api, compositeTexture.Base);
-                } else
-                {
-                    needleRenderer = new((ICoreClientAPI)byEntity.Api);
-                }
-
+                needleRenderer = new((ICoreClientAPI)byEntity.Api, this);
                 needleRenderer.heading = heading;
+
+                ((ICoreClientAPI)api).Event.KeyDown += Event_KeyDown;
             }
             
             handling = EnumHandHandling.PreventDefault;
+        }
+
+        private void Event_KeyDown(KeyEvent e)
+        {
+            if (e.KeyCode == (int)GlKeys.Up)
+            {
+                needleRenderer.compassZoom *= 1.1f;
+                e.Handled = true;
+            } else if (e.KeyCode == (int)GlKeys.Down)
+            {
+                needleRenderer.compassZoom *= 0.9f;
+                e.Handled = true;
+            }
         }
 
         private void DoMoveStep(Entity byEntity)
@@ -119,6 +127,8 @@ namespace CraftableCartography.Items.Compass
 
                 needleRenderer.Dispose();
                 needleRenderer = null;
+
+                ((ICoreClientAPI)api).Event.KeyDown -= Event_KeyDown;
             }
         }
 
@@ -139,6 +149,7 @@ namespace CraftableCartography.Items.Compass
             
             return true;
         }
+
         /*
         public override void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
         {

--- a/CraftableCartography/Items/Compass/Compass.cs
+++ b/CraftableCartography/Items/Compass/Compass.cs
@@ -37,9 +37,12 @@ namespace CraftableCartography.Items.Compass
             {
                 capi ??= byEntity.Api as ICoreClientAPI;
 
-                gui ??= new(capi);
-                gui.TryOpen();
-                gui.SetText(GetText());
+                if (api.ModLoader.GetModSystem<CraftableCartographyModSystem>().Config.modConfig.CompassTextBox)
+                {
+                    gui ??= new(capi);
+                    gui.TryOpen();
+                    gui.SetText(GetText());
+                }
 
                 needleRenderer = new(capi, this);
                 needleRenderer.heading = heading;
@@ -127,7 +130,7 @@ namespace CraftableCartography.Items.Compass
             {
                 DoMoveStep(byEntity);
 
-                gui.SetText(GetText());
+                gui?.SetText(GetText());
 
                 needleRenderer.heading = heading;
             }
@@ -139,7 +142,7 @@ namespace CraftableCartography.Items.Compass
         {
             if (byEntity.Api.Side == EnumAppSide.Client)
             {
-                gui.TryClose();
+                gui?.TryClose();
 
                 needleRenderer.Dispose();
                 needleRenderer = null;

--- a/CraftableCartography/Items/Compass/Compass.cs
+++ b/CraftableCartography/Items/Compass/Compass.cs
@@ -32,7 +32,15 @@ namespace CraftableCartography.Items.Compass
                 gui.TryOpen();
                 gui.SetText(GetText());
 
-                needleRenderer = new((ICoreClientAPI)byEntity.Api);
+                CompositeTexture compositeTexture;
+                if (Textures.TryGetValue("tinbronze", out compositeTexture))
+                {
+                    needleRenderer = new((ICoreClientAPI)byEntity.Api, compositeTexture.Base);
+                } else
+                {
+                    needleRenderer = new((ICoreClientAPI)byEntity.Api);
+                }
+
                 needleRenderer.heading = heading;
             }
             

--- a/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
+++ b/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace CraftableCartography.Items.Compass
 {
@@ -56,13 +57,41 @@ namespace CraftableCartography.Items.Compass
 
             api.Event.RegisterRenderer(this, EnumRenderStage.Ortho);
 
+            PrepareMesh();
+        }
+
+        void PrepareMesh()
+        {
+            /*
             needleMeshData = new(3, 4, false, false, true, false);
 
-            needleMeshData.AddVertexSkipTex(-0.2f, 0, 0);
-            needleMeshData.AddVertexSkipTex(0.2f, 0, 0);
+            needleMeshData.AddVertexSkipTex(-0.1f, 0, 0);
+            needleMeshData.AddVertexSkipTex(0.1f, 0, 0);
             needleMeshData.AddVertexSkipTex(0, -1.5f, 0);
 
             needleMeshData.AddIndices(new int[] { 0, 1, 2, 0 });
+            */
+
+            needleMeshData = new(721, 720*6, false, false, true, false);
+
+            float lineWidth = 1.1f;
+
+            for (int i = 0; i < 359; i++)
+            {
+                double angle = i * (Math.PI / 180);
+                
+                float x = (float)Math.Sin(angle);
+                float y = (float)-Math.Cos(angle);
+
+                needleMeshData.AddVertexSkipTex(x, y, 0);
+                needleMeshData.AddVertexSkipTex(x * lineWidth, y * lineWidth, 0);
+
+                if (i > 0)
+                {
+                    needleMeshData.AddIndices(new int[] { (i * 2) - 2, (i * 2) - 1, (i * 2) + 0 });
+                    needleMeshData.AddIndices(new int[] { (i * 2) + 0, (i * 2) - 1, (i * 2) + 1 });
+                }
+            }
 
             if (needleMeshRef is null) needleMeshRef = api.Render.UploadMesh(needleMeshData);
             else api.Render.UpdateMesh(needleMeshRef, needleMeshData);
@@ -91,8 +120,11 @@ namespace CraftableCartography.Items.Compass
             shader.UniformMatrix("projectionMatrix", api.Render.CurrentProjectionMatrix);
 
             api.Render.GlPushMatrix();
-            api.Render.GlTranslate(api.Render.FrameWidth / 2, api.Render.FrameHeight / 2, 0);
-            api.Render.GlScale(36, 36, 0);
+            api.Render.GlTranslate(
+                api.Render.FrameWidth / 2,
+                api.Render.FrameHeight * 0.65f, 
+                0);
+            api.Render.GlScale(48, 48, 0);
             api.Render.GlRotate(compassAngle, 0, 0, 1);
             shader.UniformMatrix("modelViewMatrix", api.Render.CurrentModelviewMatrix);
             api.Render.GlPopMatrix();

--- a/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
+++ b/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using System;
 using Vintagestory.API.Client;
+using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.Client.NoObf;
 
@@ -26,6 +27,8 @@ namespace CraftableCartography.Items.Compass
             }
         }
 
+        public float compassZoom = 1f;
+
         private float compassAngle;
 
         private MeshData[] meshDatas;
@@ -35,7 +38,9 @@ namespace CraftableCartography.Items.Compass
         private MeshRef[] labelMeshRefs;
         private LoadedTexture[] labelTextures;
 
-        private int textureID;
+        private Item item;
+
+        private TextureAtlasPosition itemTexturePosition;
 
         public double RenderOrder
         {
@@ -53,26 +58,12 @@ namespace CraftableCartography.Items.Compass
             }
         }
 
-        public HudCompassNeedleRenderer(ICoreClientAPI api)
-        { 
-            Init(api, api.Render.GetOrLoadTexture("game:textures/block/ingot/tinbronze"));
-        }
-
-        public HudCompassNeedleRenderer(ICoreClientAPI api, string texturePath)
-        {
-            Init(api, api.Render.GetOrLoadTexture(texturePath));
-        }
-
-        
-        public HudCompassNeedleRenderer(ICoreClientAPI api, int textureID)
-        {
-            Init(api, textureID);
-        }
-
-        private void Init(ICoreClientAPI api, int textureID)
+        public HudCompassNeedleRenderer(ICoreClientAPI api, Item item)
         {
             this.api = api;
-            this.textureID = textureID;
+            this.item = item;
+
+            itemTexturePosition = api.ItemTextureAtlas.GetPosition(item, "tinbronze");
 
             api.Event.RegisterRenderer(this, EnumRenderStage.Ortho);
 
@@ -118,6 +109,8 @@ namespace CraftableCartography.Items.Compass
 
             circleMeshData.AddIndices(new int[] { 718, 719, 0 });
             circleMeshData.AddIndices(new int[] { 0, 719, 1 });
+
+            circleMeshData.SetTexPos(itemTexturePosition);
 
             meshDatas[0] = circleMeshData;
 
@@ -165,6 +158,8 @@ namespace CraftableCartography.Items.Compass
                 lineMesh.AddVertex(p3.X, p3.Z, 0, (p3.X / 4) + 0.5f, (p3.Z / 4) + 0.5f);
 
                 lineMesh.AddIndices(new int[] { 0, 1, 2 });
+
+                lineMesh.SetTexPos(itemTexturePosition);
 
                 meshDatas[(int)((i / 22.5) + 1)] = lineMesh;
 
@@ -247,7 +242,7 @@ namespace CraftableCartography.Items.Compass
             shader.NoTexture = 0f;
             shader.OverlayOpacity = 0f;
             shader.NormalShaded = 0;
-            shader.Tex2d2D = textureID;
+            shader.Tex2d2D = itemTexturePosition.atlasTextureId;
 
             shader.ProjectionMatrix = api.Render.CurrentProjectionMatrix;
 
@@ -262,7 +257,7 @@ namespace CraftableCartography.Items.Compass
             shader.UniformMatrix("projectionMatrix", api.Render.CurrentProjectionMatrix);
             */
 
-            float vPosM = 0.7f;
+            float vPosM = compassZoom;
             float scale = (api.Render.FrameHeight * (vPosM - 0.5f)) / 2;
             
             Matrixf viewMatrix = new(api.Render.CurrentModelviewMatrix);

--- a/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
+++ b/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
@@ -194,7 +194,7 @@ namespace CraftableCartography.Items.Compass
                     string str = i_hdg == 0 ? "-N-" : i_hdg.ToString();
                     CairoFont font = CairoFont.WhiteDetailText()
                         .WithColor(new double[] { 1, 1, 1, 1 })
-                        .WithFontSize(30)
+                        .WithFontSize(32)
                         .WithStroke(new double[] { 0, 0, 0, 1 }, 2);
                     if (i_hdg == 0)
                     {

--- a/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
+++ b/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+
+namespace CraftableCartography.Items.Compass
+{
+    internal class HudCompassNeedleRenderer : IRenderer
+    {
+        ICoreClientAPI api;
+
+        private float _heading;
+
+        public float heading
+        {
+            get
+            {
+                return _heading;
+            }
+            set
+            {
+                _heading = value;
+
+                compassAngle = 360 - heading;
+            }
+        }
+
+        private float compassAngle;
+
+        private MeshData needleMeshData;
+        private MeshRef needleMeshRef;
+
+        public double RenderOrder
+        {
+            get
+            {
+                return 1;
+            }
+        }
+
+        public int RenderRange 
+        {
+            get
+            {
+                return 10;
+            }
+        }
+
+        public HudCompassNeedleRenderer(ICoreClientAPI api)
+        {
+            this.api = api;
+
+            api.Event.RegisterRenderer(this, EnumRenderStage.Ortho);
+
+            needleMeshData = new(3, 4, false, false, true, false);
+
+            needleMeshData.AddVertexSkipTex(-0.2f, 0, 0);
+            needleMeshData.AddVertexSkipTex(0.2f, 0, 0);
+            needleMeshData.AddVertexSkipTex(0, -1.5f, 0);
+
+            needleMeshData.AddIndices(new int[] { 0, 1, 2, 0 });
+
+            if (needleMeshRef is null) needleMeshRef = api.Render.UploadMesh(needleMeshData);
+            else api.Render.UpdateMesh(needleMeshRef, needleMeshData);
+        }
+
+        public void Dispose()
+        {
+            if (needleMeshRef is not null)
+            {
+                api.Render.DeleteMesh(needleMeshRef);
+                needleMeshRef = null;
+            }
+        }
+
+        public void OnRenderFrame(float deltaTime, EnumRenderStage stage)
+        {
+            if (needleMeshRef is null) return;
+            
+            IShaderProgram shader = api.Render.CurrentActiveShader;
+
+            shader.Uniform("rgbaIn", new Vec4f(1,1,1,1));
+            shader.Uniform("extraGlow", 0);
+            shader.Uniform("applyColor", 0);
+            shader.Uniform("tex2d", 0);
+            shader.Uniform("noTexture", 1.0F);
+            shader.UniformMatrix("projectionMatrix", api.Render.CurrentProjectionMatrix);
+
+            api.Render.GlPushMatrix();
+            api.Render.GlTranslate(api.Render.FrameWidth / 2, api.Render.FrameHeight / 2, 0);
+            api.Render.GlScale(36, 36, 0);
+            api.Render.GlRotate(compassAngle, 0, 0, 1);
+            shader.UniformMatrix("modelViewMatrix", api.Render.CurrentModelviewMatrix);
+            api.Render.GlPopMatrix();
+
+            api.Render.RenderMesh(needleMeshRef);
+        }
+    }
+}

--- a/CraftableCartography/Patches/HudToolbarPatches.cs
+++ b/CraftableCartography/Patches/HudToolbarPatches.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Vintagestory.API.Client;
+using Vintagestory.API.Datastructures;
+using Vintagestory.Client.NoObf;
+
+namespace CraftableCartography.Patches
+{
+    [HarmonyPatch]
+    public static class HudToolbarPatches
+    {
+        public delegate void OnMouseWheelDelegate(ref MouseWheelEventArgs args);
+
+        public static event OnMouseWheelDelegate OnMouseWheel;
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(HudHotbar), "OnMouseWheel")]
+        public static bool OnMouseWheelPatch(MouseWheelEventArgs args)
+        {
+            if (OnMouseWheel is not null)
+            {
+                foreach (OnMouseWheelDelegate d in OnMouseWheel.GetInvocationList())
+                {
+                    d.Invoke(ref args);
+                    if (args.IsHandled) return false;
+                }
+            }
+            
+            return true;
+        }
+    }
+}

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,5 +1,1 @@
-- Added fancy new graphical compass display! Much better than just showing a numerical heading
-
-TODO
-- Background for compass? 
-- Disable text output for compass (make config option to re-enable?)
+Added fancy new graphical compass display! Much better than just showing a numerical heading

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,5 +1,5 @@
-New alternative mechanic. 
+- Added fancy new graphical compass display! Much better than just showing a numerical heading
 
-Instead of denying the opening of the (mini)map without the relevant items, it will instead simply not render the terrain. 
-
-This can be toggled in the config. 
+TODO
+- Implement zooming on scroll (also min/max zoom levels)
+- Disable text output for compass (make config option to re-enable?)

--- a/CraftableCartography/changes.txt
+++ b/CraftableCartography/changes.txt
@@ -1,5 +1,5 @@
 - Added fancy new graphical compass display! Much better than just showing a numerical heading
 
 TODO
-- Implement zooming on scroll (also min/max zoom levels)
+- Background for compass? 
 - Disable text output for compass (make config option to re-enable?)

--- a/resources/assets/craftablecartography/recipes/grid/compass.json
+++ b/resources/assets/craftablecartography/recipes/grid/compass.json
@@ -11,23 +11,10 @@
       "type": "item",
       "code": "game:nugget-*"
     },
-    "B": {
-      "type": "block",
-      "code": "game:bowl-*-fired"
-    },
     "P": {
       "type": "item",
       "code": "compassframe-*",
       "name": "frame"
-    }
-  },
-  "attributes": {
-    "liquidContainerProps": {
-      "requiresContent": {
-        "type": "item",
-        "code": "waterportion"
-      },
-      "requiresLitres": 1
     }
   },
   "output": {

--- a/resources/assets/craftablecartography/recipes/grid/compassprimitive.json
+++ b/resources/assets/craftablecartography/recipes/grid/compassprimitive.json
@@ -9,7 +9,7 @@
     },
     "B": {
       "type": "block",
-      "code": "game:bowl-*-fired"
+      "code": "game:bowl-*fired"
     }
   },
   "attributes": {

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "A more immersive map & navigation experience",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "dependencies": {
         "game": "*"
     }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "A more immersive map & navigation experience",
-    "version": "0.1.10",
+    "version": "0.2.11",
     "dependencies": {
         "game": "*"
     }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "A more immersive map & navigation experience",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "dependencies": {
         "game": "*"
     }


### PR DESCRIPTION
- Added fancy new graphical compass display! Much better than just showing a numerical heading. It can be zoomed with the mouse wheel or arrow keys, and its texture changes depending on the metal of your compass.
- Added new config option to re-enable the old compass display
- Changed compass recipe, removing the bowl of water. Why did it need a bowl of water? 
- Changed primitive compass recipe, so it should work fine on both 1.20 and 1.21, no separate versions required. Thanks to millennIumAMbiguity on Github for this one. :]