### PR TITLE
Fix: Some heading labels not rendering

### DIFF
--- a/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
+++ b/CraftableCartography/Items/Compass/HudCompassNeedleRenderer.cs
@@ -227,7 +227,7 @@ namespace CraftableCartography.Items.Compass
                         labelTextures[k] = labelTexture;
 
                         float labelHeight = 0.2f;
-                        float labelXScale = labelTexture.Width / labelTexture.Height;
+                        float labelXScale = (float)labelTexture.Width / labelTexture.Height;
 
                         Vec3f lp1 = new(-labelHeight * labelXScale * 0.5f, 0, 2f + labelHeight);
                         Vec3f lp2 = new(labelHeight * labelXScale * 0.5f, 0, 2f);

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
         "Professor Cupcake"
     ],
     "description": "A more immersive map & navigation experience",
-    "version": "0.2.14",
+    "version": "0.2.15",
     "dependencies": {
         "game": "*"
     }


### PR DESCRIPTION
Some heading labels weren't rendering because integer division was being used causing the width to sometimes be zero.